### PR TITLE
Update bayes.py

### DIFF
--- a/Chapter_1/bayes.py
+++ b/Chapter_1/bayes.py
@@ -231,7 +231,7 @@ def main():
             print("P1 = {:.3f}, P2 = {:.3f}, P3 = {:.3f}"
                   .format(app.p1, app.p2, app.p3))
         else:
-            cv.circle(app.img, (sailor_x, sailor_y), 3, (255, 0, 0), -1)
+            cv.circle(app.img, (sailor_x.item(0), sailor_y.item(0)), 3, (255, 0, 0), -1)
             cv.imshow('Search Area', app.img)
             cv.waitKey(1500)
             main()


### PR DESCRIPTION
LINE #234 - fixed "TypeError: only integer scalar arrays can be converted to a scalar index" in line #234 which caused the program to crash and preventing it from drawing the circle when the sailor coordinates are retrieved.